### PR TITLE
add block force push

### DIFF
--- a/ghwebhook.UnitTests/GitHubWebhookEventProcessor.UnitTests.cs
+++ b/ghwebhook.UnitTests/GitHubWebhookEventProcessor.UnitTests.cs
@@ -113,7 +113,9 @@ public class GitHubWebhookEventProcessorUnitTests
                 (r.Rules[1] as PullRequestRule)!.Parameters.RequiredApprovingReviewCount == 2 &&
                 (r.Rules[1] as PullRequestRule)!.Parameters.RequiredReviewThreadResolution == true &&
                 (r.Rules[1] as PullRequestRule)!.Parameters.AllowedMergeMethods.Contains("squash") &&
-                (r.Rules[1] as PullRequestRule)!.Parameters.AllowedMergeMethods.Contains("merge")),
+                (r.Rules[1] as PullRequestRule)!.Parameters.AllowedMergeMethods.Contains("merge") &&
+                r.Rules[2] is NonFastForwardRule &&
+                r.Rules.Count == 3),
             "application/json",
             "application/json",
             It.IsAny<IDictionary<string, string>>(),

--- a/ghwebhook/.gitignore
+++ b/ghwebhook/.gitignore
@@ -266,3 +266,7 @@ __pycache__/
 # pem file
 
 *.pem
+
+Properties/PublishProfiles/
+Properties/serviceDependencies*.*
+Properties/ServiceDependencies/

--- a/ghwebhook/GitHubWebhookEventProcessor.cs
+++ b/ghwebhook/GitHubWebhookEventProcessor.cs
@@ -83,7 +83,8 @@ public class GitHubWebhookEventProcessor(IGitHubClient gitHubClient, ILogger<Git
                                     RequiredReviewThreadResolution = true,
                                     AllowedMergeMethods = new() { "squash", "merge" }
                                 }
-                            }
+                            },
+                            new NonFastForwardRule()
                         }
             };
 

--- a/ghwebhook/Properties/serviceDependencies.json
+++ b/ghwebhook/Properties/serviceDependencies.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "appInsights1": {
-      "type": "appInsights"
+      "type": "appInsights",
+      "connectionId": "APPLICATIONINSIGHTS_CONNECTION_STRING"
     },
     "storage1": {
       "type": "storage",


### PR DESCRIPTION
This pull request includes several changes to the `ghwebhook` project, focusing on adding new rules, modifying existing rules, and updating configuration files. The most important changes include adding a `NonFastForwardRule` to the list of rules, updating the `.gitignore` file to exclude additional properties, and modifying the `serviceDependencies.json` configuration.

### Rule Changes:

* [`ghwebhook/GitHubWebhookEventProcessor.cs`](diffhunk://#diff-1c1d683deeb7194d7bdc3c04b6ea6c670b91685c50a2c0dd05f8c9ac1ff7617aL86-R87): Added a new `NonFastForwardRule` to the list of rules in the `HandleRepositoryCreationEventAsync` method.
* [`ghwebhook.UnitTests/GitHubWebhookEventProcessor.UnitTests.cs`](diffhunk://#diff-176cbed86018d11cf75c3426fa149232d6c627b9c580624228e94c2f055270edL116-R118): Updated the unit test to check for the presence of `NonFastForwardRule` and ensure the total count of rules is three.
